### PR TITLE
feat: add MCP tool hint annotations to particle system tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
@@ -27,7 +27,9 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
         [McpPluginTool
         (
             ParticleSystemGetToolId,
-            Title = "ParticleSystem / Get"
+            Title = "ParticleSystem / Get",
+            ReadOnlyHint = true,
+            IdempotentHint = true
         )]
         [Description("Get detailed information about a ParticleSystem component on a GameObject. " +
             "Returns particle system state and optionally serialized data for each module. " +

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
@@ -31,7 +31,8 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
         [McpPluginTool
         (
             ParticleSystemModifyToolId,
-            Title = "ParticleSystem / Modify"
+            Title = "ParticleSystem / Modify",
+            IdempotentHint = true
         )]
         [Description("Modify a ParticleSystem component on a GameObject. " +
             "Provide the data model with only the modules you want to change. " +


### PR DESCRIPTION
Adds MCP tool hint annotations to the two particle system tools as requested in issue #3.

**particle-system-get**: ReadOnlyHint=true, IdempotentHint=true
**particle-system-modify**: IdempotentHint=true

Closes #3

Generated with [Claude Code](https://claude.ai/code)