### PR TITLE
Update test asmdefs & add package testables

### DIFF
--- a/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.Tests.asmdef
@@ -5,8 +5,6 @@
         "com.IvanMurzak.Unity.MCP.Editor.Tests",
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.TestFiles",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
         "com.IvanMurzak.Unity.MCP.ParticleSystem.Runtime",
         "com.IvanMurzak.Unity.MCP.ParticleSystem.Editor"
     ],
@@ -14,10 +12,10 @@
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",
@@ -28,7 +26,9 @@
         "R3.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.ParticleSystem.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/com.IvanMurzak.Unity.MCP.ParticleSystem.Tests.asmdef
@@ -4,15 +4,14 @@
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.Tests",
         "com.IvanMurzak.Unity.MCP.TestFiles",
-        "UnityEngine.TestRunner",
         "com.IvanMurzak.Unity.MCP.ParticleSystem.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",

--- a/Unity-Package/Unity-Package.slnx
+++ b/Unity-Package/Unity-Package.slnx
@@ -1,9 +1,5 @@
 ﻿<Solution>
-  <Project Path="com.IvanMurzak.Unity.MCP.Runtime.csproj" />
-  <Project Path="com.IvanMurzak.Unity.MCP.Editor.csproj" />
-  <Project Path="com.IvanMurzak.Unity.MCP.Editor.Tests.csproj" />
   <Project Path="com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.csproj" />
-  <Project Path="com.IvanMurzak.Unity.MCP.TestFiles.csproj" />
   <Project Path="com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.Tests.csproj" />
   <Project Path="com.IvanMurzak.Unity.MCP.ParticleSystem.Tests.csproj" />
 </Solution>

--- a/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -44,5 +44,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.particlesystem"]
 }

--- a/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -47,5 +47,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.particlesystem"]
 }

--- a/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -48,5 +48,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["com.ivanmurzak.unity.mcp.particlesystem"]
 }


### PR DESCRIPTION
Refactor test assembly definitions across package and multiple Unity test projects: remove direct UnityEngine.TestRunner/UnityEditor.TestRunner references and nunit.framework.dll precompiled references, add optionalUnityReferences: ["TestAssemblies"], set defineConstraints to ["UNITY_INCLUDE_TESTS"] and clear precompiledReferences. Add "testables": ["com.ivanmurzak.unity.mcp.particlesystem"] to each test manifest so the package is discoverable by Unity test runners. Also slim down Unity-Package.slnx to include only the ParticleSystem projects. These changes migrate tests to use Unity's TestAssemblies workflow and make the package testable across the provided Unity versions.