### PR TITLE
fix(deps): adopt AIGD namespace for Unity-MCP 0.68.0

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Data/GetParticleSystemResponse.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Data/GetParticleSystemResponse.cs
@@ -11,7 +11,7 @@
 #nullable enable
 using System.ComponentModel;
 using com.IvanMurzak.ReflectorNet.Model;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
 {

--- a/Unity-Package/Assets/root/Editor/Scripts/Data/ModifyParticleSystemResponse.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Data/ModifyParticleSystemResponse.cs
@@ -10,7 +10,7 @@
 
 #nullable enable
 using System.ComponentModel;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
 {

--- a/Unity-Package/Assets/root/Editor/Scripts/Data/ParticleSystemData.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Data/ParticleSystemData.cs
@@ -11,7 +11,7 @@
 #nullable enable
 using System.ComponentModel;
 using com.IvanMurzak.ReflectorNet.Model;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
 {

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
@@ -13,7 +13,7 @@ using System;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using com.IvanMurzak.Unity.MCP.Utils;
 using Microsoft.Extensions.Logging;

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
@@ -17,7 +17,7 @@ using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using com.IvanMurzak.Unity.MCP.Utils;
 using Microsoft.Extensions.Logging;

--- a/Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemGet.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemGet.cs
@@ -10,7 +10,7 @@
 
 #nullable enable
 using System.Collections;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 

--- a/Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemModify.cs
+++ b/Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemModify.cs
@@ -12,7 +12,7 @@
 using System;
 using System.Collections;
 using com.IvanMurzak.ReflectorNet.Model;
-using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using AIGD;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;


### PR DESCRIPTION
## Summary

- Unity-MCP 0.68.0 renamed the `com.IvanMurzak.Unity.MCP.Runtime.Data` namespace to `AIGD` (Unity-MCP PR #704: "refactor: rename data model namespace to AIGD and flatten nested tool data models"). The release-notes classifier recorded it as a `refactor:` so the 0.68.0 release did not flag the breaking nature.
- The previous CI run on `main` (https://github.com/IvanMurzak/Unity-AI-ParticleSystem/actions/runs/25260880331) failed with CS0234 errors for `GameObjectRef` / `ComponentRef`, and a CS0006 cascade for stale-named DLL references that Unity recorded against the now-orphan compilation pass. The bundled NuGet folders are already at `com.IvanMurzak.McpPlugin.6.1.2` / `com.IvanMurzak.McpPlugin.Common.6.1.2` / `com.IvanMurzak.ReflectorNet.5.1.1`, so once the namespace error is resolved Unity will regenerate `.csproj` cleanly and the CS0006 metadata-file errors should clear automatically.

## Changes

`using com.IvanMurzak.Unity.MCP.Runtime.Data;` → `using AIGD;` in 7 files:
- `Unity-Package/Assets/root/Editor/Scripts/Data/GetParticleSystemResponse.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Data/ModifyParticleSystemResponse.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Data/ParticleSystemData.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs`
- `Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs`
- `Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemGet.cs`
- `Unity-Package/Assets/root/Tests/Editor/TestToolParticleSystemModify.cs`

No fully-qualified `com.IvanMurzak.Unity.MCP.Runtime.Data.*` references remain in the repo (verified with `rg`).

## Test plan

- [ ] CI green on `test_unity_plugin.yml` across Unity 2022.3.62f3 / 2023.2.22f1 / 6000.3.1f1 (editmode + playmode).
- [ ] No further CS0234 / CS0006 errors in the assemblies.