### PR TITLE
feat(skills): add SkillDescription/SkillBody to ParticleSystem tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
@@ -33,6 +33,33 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Inspect a `UnityEngine.ParticleSystem` component on a GameObject — runtime state " +
+            "(playing/paused/emitting/stopped, particle count, time) plus opt-in serialized data for any of the " +
+            "~24 particle modules (Main, Emission, Shape, Velocity, Noise, Collision, Trails, Renderer, etc.). " +
+            "Pair with '" + ParticleSystemModifyToolId + "' to write changes back.")]
+        [McpPluginSkillBody("Inspect a `UnityEngine.ParticleSystem` component on a GameObject. Returns runtime state " +
+            "(`isPlaying`, `isPaused`, `isEmitting`, `isStopped`, `particleCount`, `time`) plus opt-in serialized data " +
+            "for any of the particle modules. Use '" + ParticleSystemModifyToolId + "' afterwards to write changes back.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ParticleSystem` component (required).\n" +
+            "- `componentRef` — optional. Resolves a specific `ParticleSystem` when the GameObject has more than " +
+            "one; otherwise the first `ParticleSystem` found is used.\n" +
+            "- `includeMain`, `includeEmission`, `includeShape`, `includeVelocityOverLifetime`, " +
+            "`includeLimitVelocityOverLifetime`, `includeInheritVelocity`, `includeLifetimeByEmitterSpeed`, " +
+            "`includeForceOverLifetime`, `includeColorOverLifetime`, `includeColorBySpeed`, " +
+            "`includeSizeOverLifetime`, `includeSizeBySpeed`, `includeRotationOverLifetime`, " +
+            "`includeRotationBySpeed`, `includeExternalForces`, `includeNoise`, `includeCollision`, " +
+            "`includeTrigger`, `includeSubEmitters`, `includeTextureSheetAnimation`, `includeLights`, " +
+            "`includeTrails`, `includeCustomData`, `includeRenderer` — per-module toggles. `includeMain` defaults " +
+            "to `true`; everything else defaults to `false`.\n" +
+            "- `includeAll` — when `true`, overrides every per-module flag and emits all modules.\n" +
+            "- `deepSerialization` — when `true`, recurses through nested objects via ReflectorNet; otherwise only " +
+            "top-level members are serialized (cheaper, smaller payload).\n\n" +
+            "## Behavior\n\n" +
+            "Only the modules whose include-flags resolve to `true` are serialized — this keeps responses small " +
+            "when you only need one or two modules. `includeRenderer` reads the sibling " +
+            "`UnityEngine.ParticleSystemRenderer` component on the same GameObject and is skipped silently when " +
+            "no renderer is present. The whole call runs on the Unity main thread.")]
         [Description("Get detailed information about a ParticleSystem component on a GameObject. " +
             "Returns particle system state and optionally serialized data for each module. " +
             "Use the boolean flags to request specific modules. " +

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
@@ -37,6 +37,28 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
             IdempotentHint = true,
             OpenWorldHint = false
         )]
+        [McpPluginSkillDescription("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass " +
+            "`SerializedMember` payloads only for the modules you want to change; everything else is left alone. " +
+            "Use '" + ParticleSystemGetToolId + "' first to inspect the current structure.")]
+        [McpPluginSkillBody("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass `SerializedMember` " +
+            "payloads only for the modules you want to change; omitted modules are left untouched. Use " +
+            "'" + ParticleSystemGetToolId + "' first to inspect the current structure so the diff is targeted.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the GameObject hosting the `ParticleSystem` component (required).\n" +
+            "- `componentRef` — optional. Resolves a specific `ParticleSystem` when the GameObject has more than " +
+            "one; otherwise the first `ParticleSystem` found is used.\n" +
+            "- `main`, `emission`, `shape`, `velocityOverLifetime`, `limitVelocityOverLifetime`, " +
+            "`inheritVelocity`, `lifetimeByEmitterSpeed`, `forceOverLifetime`, `colorOverLifetime`, `colorBySpeed`, " +
+            "`sizeOverLifetime`, `sizeBySpeed`, `rotationOverLifetime`, `rotationBySpeed`, `externalForces`, " +
+            "`noise`, `collision`, `trigger`, `subEmitters`, `textureSheetAnimation`, `lights`, `trails`, " +
+            "`customData`, `renderer` — optional `SerializedMember` payloads per module. Include only the " +
+            "properties you want to change.\n\n" +
+            "## Behavior\n\n" +
+            "Each non-null module is applied via `Reflector.TryModify` and logged with a `[ModuleName]` prefix in " +
+            "the response's `logs` array. The `renderer` payload targets the sibling " +
+            "`UnityEngine.ParticleSystemRenderer` component on the same GameObject; if absent, the call logs the " +
+            "miss instead of throwing. When at least one module was modified, the GameObject and the " +
+            "`ParticleSystem` are marked dirty so the change persists. The whole call runs on the Unity main thread.")]
         [Description("Modify a ParticleSystem component on a GameObject. " +
             "Provide the data model with only the modules you want to change. " +
             "Use '" + ParticleSystemGetToolId + "' first to inspect the ParticleSystem structure before modifying. " +

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -28,7 +28,7 @@
     "unity": "2022.3",
     "description": "AI-powered tools for Unity ParticleSystem workflow. Inspect and modify ParticleSystem components via natural language commands—configure emission, shape, velocity curves, color gradients, and all modules without manual inspector navigation. Ideal for rapid prototyping and procedural effects generation. Built on top of the AI Game Developer (Unity-MCP) platform.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.72.1",
+        "com.ivanmurzak.unity.mcp": "0.72.2",
         "com.unity.modules.particlesystem": "1.0.0"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "0.72.1",
+    "com.ivanmurzak.unity.mcp": "0.72.2",
     "com.unity.ide.visualstudio": "2.0.26",
     "com.unity.test-framework": "1.1.33",
     "com.unity.modules.assetbundle": "1.0.0",


### PR DESCRIPTION
## Summary

Follow-on to Unity-MCP [PR #758](https://github.com/IvanMurzak/Unity-MCP/pull/758) — extends the `[McpPluginSkillDescription]` / `[McpPluginSkillBody]` coverage from the core Unity-MCP plugin to this extension. The two tool methods exposed by this package — `particle-system-get` and `particle-system-modify` — now carry both attributes.

## Changes

- Bumped `com.ivanmurzak.unity.mcp` dependency from `0.72.1` → `0.72.2` in `Unity-Package/Assets/root/package.json` and `Unity-Package/Packages/manifest.json`. The new attributes were introduced in `0.72.2`.
- `ParticleSystem.Get.cs` — added `[McpPluginSkillDescription]` (concise summary suitable for the SKILL.md YAML front-matter, well under the 1024-char cap) and `[McpPluginSkillBody]` (long-form markdown with `## Inputs` and `## Behavior` sections).
- `ParticleSystem.Modify.cs` — same treatment.
- `[Description]` payloads are left **byte-identical** to `main`, so the MCP `tools/list` wire response is unchanged.

## Out of scope

- The generated `Unity-Package/.claude/skills/particle-system-*/SKILL.md` files are intentionally left untouched in this PR. They should be regenerated by running the `unity-skill-generate` MCP tool inside Unity and committed as a follow-up (same round-trip pattern as Unity-MCP PR #758 commit `57334844`).

## Verification

- Static review confirms both new attributes are correctly applied and the `[Description]` strings are byte-identical to `main`.
- A reviewer with Unity open should run `unity-skill-generate` to confirm the regenerated SKILL.md files include the new `description:` YAML field and body markdown.

Refs IvanMurzak/Unity-MCP#729, IvanMurzak/Unity-MCP#758

🤖 Generated with [Claude Code](https://claude.com/claude-code)