### PR TITLE
fix: resolve CS0618 obsolete-alias warnings in ParticleSystem Editor tools

### DIFF
--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Get.cs
@@ -24,7 +24,7 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
     {
         public const string ParticleSystemGetToolId = "particle-system-get";
 
-        [McpPluginTool
+        [AiTool
         (
             ParticleSystemGetToolId,
             Title = "ParticleSystem / Get",
@@ -33,11 +33,11 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
             IdempotentHint = true,
             OpenWorldHint = false
         )]
-        [McpPluginSkillDescription("Inspect a `UnityEngine.ParticleSystem` component on a GameObject — runtime state " +
+        [AiSkillDescription("Inspect a `UnityEngine.ParticleSystem` component on a GameObject — runtime state " +
             "(playing/paused/emitting/stopped, particle count, time) plus opt-in serialized data for any of the " +
             "~24 particle modules (Main, Emission, Shape, Velocity, Noise, Collision, Trails, Renderer, etc.). " +
             "Pair with '" + ParticleSystemModifyToolId + "' to write changes back.")]
-        [McpPluginSkillBody("Inspect a `UnityEngine.ParticleSystem` component on a GameObject. Returns runtime state " +
+        [AiSkillBody("Inspect a `UnityEngine.ParticleSystem` component on a GameObject. Returns runtime state " +
             "(`isPlaying`, `isPaused`, `isEmitting`, `isStopped`, `particleCount`, `time`) plus opt-in serialized data " +
             "for any of the particle modules. Use '" + ParticleSystemModifyToolId + "' afterwards to write changes back.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.Modify.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
     {
         public const string ParticleSystemModifyToolId = "particle-system-modify";
 
-        [McpPluginTool
+        [AiTool
         (
             ParticleSystemModifyToolId,
             Title = "ParticleSystem / Modify",
@@ -37,10 +37,10 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
             IdempotentHint = true,
             OpenWorldHint = false
         )]
-        [McpPluginSkillDescription("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass " +
+        [AiSkillDescription("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass " +
             "`SerializedMember` payloads only for the modules you want to change; everything else is left alone. " +
             "Use '" + ParticleSystemGetToolId + "' first to inspect the current structure.")]
-        [McpPluginSkillBody("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass `SerializedMember` " +
+        [AiSkillBody("Modify a `UnityEngine.ParticleSystem` component on a GameObject. Pass `SerializedMember` " +
             "payloads only for the modules you want to change; omitted modules are left untouched. Use " +
             "'" + ParticleSystemGetToolId + "' first to inspect the current structure so the diff is targeted.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.cs
+++ b/Unity-Package/Assets/root/Editor/Scripts/Tools/ParticleSystem.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Editor
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_ParticleSystem
     {
         // empty


### PR DESCRIPTION
## Summary
- Replace deprecated Unity-MCP attribute aliases with their current names across the ParticleSystem Editor tool scripts (7 renames in ParticleSystem.cs / ParticleSystem.Get.cs / ParticleSystem.Modify.cs): `McpPluginToolType`->`AiToolType`, `McpPluginTool`->`AiTool`, `McpPluginSkillDescription`->`AiSkillDescription`, `McpPluginSkillBody`->`AiSkillBody`.
- Pure mechanical rename; drop-in replacements from the same `com.IvanMurzak.McpPlugin` namespace (existing using directive already covers the new names). No behavior change, no `package.json` bump.

## Test plan
- [x] Unity-Test-Project (Unity 6.5 / 6000.5.0b10) compiles cleanly against the edited extension. `com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.dll` built with zero compiler diagnostics; full project-wide compile is green (Editor.log shows no `error CS` lines).

Closes #17