### PR TITLE
chore: bump version to 1.2.10

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp.particlesystem";
-        public const string Version = "1.2.9";
+        public const string Version = "1.2.10";
 
         static Installer()
         {

--- a/Unity-Package/Assets/root/package.json
+++ b/Unity-Package/Assets/root/package.json
@@ -24,7 +24,7 @@
         "renderer",
         "editor-tooling"
     ],
-    "version": "1.2.9",
+    "version": "1.2.10",
     "unity": "2022.3",
     "description": "AI-powered tools for Unity ParticleSystem workflow. Inspect and modify ParticleSystem components via natural language commands—configure emission, shape, velocity curves, color gradients, and all modules without manual inspector navigation. Ideal for rapid prototyping and procedural effects generation. Built on top of the AI Game Developer (Unity-MCP) platform.",
     "dependencies": {


### PR DESCRIPTION
Automated version bump to `1.2.10` triggered via workflow dispatch. PR opened manually by repo owner because the `bump_version.yml` workflow's `gh pr create` step is blocked by the repo's 'Allow GitHub Actions to create and approve pull requests' setting being disabled.