### PR TITLE
chore: minimal Unity-Package project manifest (deps via package.json)

### DIFF
--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "0.79.1",
-    "com.unity.ide.visualstudio": "2.0.26",
-    "com.unity.test-framework": "1.1.33",
     "com.unity.modules.assetbundle": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.imgui": "1.0.0",


### PR DESCRIPTION
Make the Unity-Package authoring project carry no explicit dependencies — only `com.unity.modules.*` engine modules remain. Everything else (com.ivanmurzak.unity.mcp, com.unity.test-framework, the feature package, IDE/template cruft) now resolves transitively from the embedded package's own `package.json` via the OpenUPM scoped registry. Mirrors the maintainer's Cinemachine change. Package source-of-truth = package.json; the project manifest no longer duplicates/pins deps.

Note: only the project manifest changes (not the embedded package). Verified each package's asmdefs don't reference the removed entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)