### PR TITLE
AI Game Developer update

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp.particlesystem";
-        public const string Version = "1.2.21";
+        public const string Version = "1.2.22";
 
         static Installer()
         {

--- a/Unity-Package/Packages/com.ivanmurzak.unity.mcp.particlesystem/package.json
+++ b/Unity-Package/Packages/com.ivanmurzak.unity.mcp.particlesystem/package.json
@@ -24,11 +24,11 @@
         "renderer",
         "editor-tooling"
     ],
-    "version": "1.2.21",
+    "version": "1.2.22",
     "unity": "2022.3",
     "description": "AI-powered tools for Unity ParticleSystem workflow. Inspect and modify ParticleSystem components via natural language commands—configure emission, shape, velocity curves, color gradients, and all modules without manual inspector navigation. Ideal for rapid prototyping and procedural effects generation. Built on top of the AI Game Developer (Unity-MCP) platform.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.82.1",
+        "com.ivanmurzak.unity.mcp": "0.82.2",
         "com.unity.modules.particlesystem": "1.0.0"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/packages-lock.json
+++ b/Unity-Package/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.82.1",
+      "version": "0.82.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Automated dependency + version bump produced by `.scripts/cli.py bump-unity-extensions`.

- `com.ivanmurzak.unity.mcp` dependency -> `0.82.2`
- extension package version -> `1.2.22`

Squash auto-merge is enabled; GitHub will merge this PR automatically once the required CI checks are green.