### PR TITLE
ci: pin unity-test-runner to node24 fix (PR #304)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           key: Library-Unity-Installer
 
       - name: Test Unity Installer (EditMode)
-        uses: game-ci/unity-test-runner@v4
+        uses: game-ci/unity-test-runner@08fd329f00a18efa297140b14ac28ebce742759e # node24 runtime (PR #304); revert to @v4 once game-ci moves the tag
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -101,7 +101,7 @@ jobs:
         run: echo "image=unityci/editor:ubuntu-${{ inputs.unityVersion }}-${{ matrix.platform }}-3" >> $GITHUB_OUTPUT
         shell: bash
 
-      - uses: game-ci/unity-test-runner@v4
+      - uses: game-ci/unity-test-runner@08fd329f00a18efa297140b14ac28ebce742759e # node24 runtime (PR #304); revert to @v4 once game-ci moves the tag
         id: tests
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
`game-ci/unity-test-runner@v4` still uses the **Node.js 20** action runtime (GitHub is sunsetting it). The **node24** fix ([game-ci PR #304](https://github.com/game-ci/unity-test-runner/pull/304)) is on upstream `main` (`08fd329f00a18efa297140b14ac28ebce742759e`) but not yet in the `v4` tag/any release. This pins `unity-test-runner` to that commit in 2 workflow file(s). `unity-builder@v5` already runs node24. Revert to `@v4` once game-ci moves the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)