### PR TITLE
Release: Unity-MCP 0.83.1 cascade

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Particle System Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.ParticleSystem.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp.particlesystem";
-        public const string Version = "1.2.24";
+        public const string Version = "1.2.25";
 
         static Installer()
         {

--- a/Unity-Package/Packages/com.ivanmurzak.unity.mcp.particlesystem/package.json
+++ b/Unity-Package/Packages/com.ivanmurzak.unity.mcp.particlesystem/package.json
@@ -24,11 +24,11 @@
         "renderer",
         "editor-tooling"
     ],
-    "version": "1.2.24",
+    "version": "1.2.25",
     "unity": "2022.3",
     "description": "AI-powered tools for Unity ParticleSystem workflow. Inspect and modify ParticleSystem components via natural language commands—configure emission, shape, velocity curves, color gradients, and all modules without manual inspector navigation. Ideal for rapid prototyping and procedural effects generation. Built on top of the AI Game Developer (Unity-MCP) platform.",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.82.4",
+        "com.ivanmurzak.unity.mcp": "0.83.1",
         "com.unity.modules.particlesystem": "1.0.0"
     },
     "scopedRegistries": [

--- a/Unity-Package/Packages/packages-lock.json
+++ b/Unity-Package/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.82.4",
+      "version": "0.83.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Automated release cascade for [Unity-MCP 0.83.1](https://github.com/IvanMurzak/Unity-MCP/releases/tag/0.83.1).

- Bumps the `com.ivanmurzak.unity.mcp` dependency to `0.83.1`.
- Patch-bumps this extension's own version (skipped for Unity-AI-Tools-Template).
- When the release changed bundled NuGet DLLs: refreshes `Assets/Plugins/NuGet/` drops and per-Unity-version `.meta` files across Unity-Package and Unity-Tests projects.

Merge only after every check is green (enforced by the branch ruleset). Opened by the unity-mcp/plugin release pipeline (iteration 03b).