### PR TITLE
fix(ci): download-artifact v6 -> v7 (v6 is still Node20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,19 +384,19 @@ jobs:
       version: ${{ needs.check-version-tag.outputs.version }}
     steps:
       - name: Download release notes artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-notes
           path: ./release-notes
 
       - name: Download Unity installer artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: unity-installer-package
           path: ./assets
 
       - name: Download signed UPM package artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: signed-upm-package
           path: ./assets


### PR DESCRIPTION
Follow-up correction to the Node20 sweep.

`actions/download-artifact@v6` declares `runs.using: node20` — unlike its sibling `actions/upload-artifact@v6`, which is `node24`. The two repos diverged at v6, so the sweep target of v6 did **not** clear the deprecation.

| ref | `runs.using` |
|---|---|
| `download-artifact@v4` / `@v5` / `@v6` | node20 |
| `download-artifact@v7` | **node24** |
| `download-artifact@v8` | node24, but makes digest-mismatch a hard error |

Targets v7: Node24-capable without v8 stricter digest behaviour.

Generated with [Claude Code](https://claude.com/claude-code)